### PR TITLE
Add Google Apps Script .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Google Apps Script development
+# Ignore dependencies installed by clasp
+node_modules/
+
+# Ignore clasp project settings
+.clasp.json
+
+# MacOS and Windows temporary files
+.DS_Store
+Thumbs.db
+
+# Logs and temporary directories
+*.log
+tmp/
+TEMP/
+
+# IDE settings
+.vscode/
+


### PR DESCRIPTION
## Summary
- add a basic `.gitignore` for Google Apps Script projects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b8f3eda9483319322b2e67802a67b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a `.gitignore` file to prevent unnecessary files and directories from being tracked in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->